### PR TITLE
Remove deprecated context and print functions from auth/saml

### DIFF
--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -84,25 +84,25 @@ class auth_plugin_saml extends auth_plugin_base {
     * Returns array containg attribute mappings between Moodle and Identity Provider.
     */
     function get_attributes() {
-        $configarray = (array) $this->config;
+	    $configarray = (array) $this->config;
 
         if(isset($this->userfields)) {
             $fields = $this->userfields;
         }
         else {
-            $fields = array("firstname", "lastname", "email", "phone1", "phone2",
+        	$fields = array("firstname", "lastname", "email", "phone1", "phone2",
 			    "department", "address", "city", "country", "description",
 			    "idnumber", "lang", "guid");
         }
 
-        $moodleattributes = array();
-        foreach ($fields as $field) {
-            if (isset($configarray["field_map_$field"])) {
-                $moodleattributes[$field] = $configarray["field_map_$field"];
-            }
-        }
+	    $moodleattributes = array();
+	    foreach ($fields as $field) {
+	        if (isset($configarray["field_map_$field"])) {
+		        $moodleattributes[$field] = $configarray["field_map_$field"];
+	        }
+	    }
 
-        return $moodleattributes;
+	    return $moodleattributes;
     }
 
     /**
@@ -127,7 +127,7 @@ class auth_plugin_saml extends auth_plugin_base {
     function loginpage_hook() {
 
 	    global $CFG;
-	
+
         if (empty($CFG->alternateloginurl) && !($_GET['saml'] === 'false')) {
             $CFG->alternateloginurl = $CFG->wwwroot.'/auth/saml/login.php';
         }
@@ -154,7 +154,7 @@ class auth_plugin_saml extends auth_plugin_base {
     * @param array $page An object containing all the data for this page.
     */
 
-    function config_form($config, &$err, $user_fields) {
+    function config_form($config, $err, $user_fields) {
 	    global $CFG, $DB;
 
         $dbman = $DB->get_manager();
@@ -188,7 +188,7 @@ class auth_plugin_saml extends auth_plugin_base {
      * A chance to validate form data, and last chance to
      * do stuff before it is inserted in config_plugin
      */
-    function validate_form(&$form, &$err) {
+    function validate_form($form, &$err) {
 
 	    if(!isset($form->auth_saml_db_reset) && !isset($form->initialize_roles)) {
 	        if (!isset ($form->samllib) || !file_exists($form->samllib.'/_autoload.php')) {
@@ -346,9 +346,9 @@ class auth_plugin_saml extends auth_plugin_base {
 	    if (!isset ($config->samllogoinfo)) {
 	        $config->samllogoinfo = 'SAML login';
 	    }
-		if (!isset ($config->autologin)) { 
-	        $config->autologin = false; 
-	    }
+	    if (!isset ($config->autologin)) { 
+            $config->autologin = false; 
+        }
 	    if (!isset ($config->samllogfile)) {
 	        $config->samllogfile = '';
 	    }
@@ -374,7 +374,6 @@ class auth_plugin_saml extends auth_plugin_base {
 	        $config->externalrolemappingsql = ''; 
 	    }
 
-
         // Save saml settings in a file        
     	$saml_param_encoded = json_encode($saml_param);
         file_put_contents(dirname(__FILE__) . '/saml_config.php', $saml_param_encoded);
@@ -390,7 +389,7 @@ class auth_plugin_saml extends auth_plugin_base {
 	    set_config('samlcourses',     $config->samlcourses,	'auth/saml');
 	    set_config('samllogoimage',   $config->samllogoimage,	'auth/saml');
 	    set_config('samllogoinfo',    $config->samllogoinfo,	'auth/saml');
-		set_config('autologin',    $config->autologin,	'auth/saml');
+	    set_config('autologin',       $config->autologin,  'auth/saml');
 	    set_config('samllogfile',         $config->samllogfile,	'auth/saml');
 	    set_config('samlhookfile',        $config->samlhookfile,	'auth/saml');
 	    set_config('moodlecoursefieldid',   $config->moodlecoursefieldid,   'auth/saml');

--- a/auth/saml/config.php
+++ b/auth/saml/config.php
@@ -36,6 +36,8 @@
     if(file_exists('saml_config.php')) {
         $contentfile = file_get_contents('saml_config.php');
         $saml_param = json_decode($contentfile);    
+    } else {
+        $saml_param = new stdClass();
     }
 
     // Set to defaults if undefined

--- a/auth/saml/error.php
+++ b/auth/saml/error.php
@@ -55,7 +55,7 @@ function saml_error($err, $urltogo=false, $logfile='') {
     }
     if($urltogo!=false) {
         echo '</div>';
-        print_continue($urltogo);
+        $OUTPUT->continue_button($urltogo);
         if($debug) {
             print_string("auth_saml_disable_debugdisplay", "auth_saml");
         }

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -52,13 +52,14 @@ define('SAML_INTERNAL', 1);
 
         global $CFG, $err, $PAGE, $OUTPUT;
         $PAGE->set_url('/auth/saml/index.php');
-        $PAGE->set_context(get_context_instance(CONTEXT_SYSTEM));
+        $PAGE->set_context(CONTEXT_SYSTEM::instance());
 
         $pluginconfig = get_config('auth/saml');
         $urltogo = $CFG->wwwroot;
         if($CFG->wwwroot[strlen($CFG->wwwroot)-1] != '/') {
             $urltogo .= '/';
         }
+
         $err['login'] = $e->getMessage();
         log_saml_error('Moodle SAML module:'. $err['login'], $pluginconfig->samllogfile);;
         saml_error($err['login'], $urltogo, $pluginconfig->samllogfile);
@@ -74,7 +75,7 @@ define('SAML_INTERNAL', 1);
     global $CFG, $USER, $SAML_COURSE_INFO, $SESSION, $err, $DB, $PAGE;
 
     $PAGE->set_url('/auth/saml/index.php');
-    $PAGE->set_context(get_context_instance(CONTEXT_SYSTEM));
+    $PAGE->set_context(CONTEXT_SYSTEM::instance());
 
     $urltogo = $CFG->wwwroot;
     if($CFG->wwwroot[strlen($CFG->wwwroot)-1] != '/') {
@@ -82,10 +83,10 @@ define('SAML_INTERNAL', 1);
     }
 
      // set return rul from wantsurl
-     If(isset($_REQUEST['wantsurl'])) {
+     if(isset($_REQUEST['wantsurl'])) {
         $urltogo = $_REQUEST['wantsurl'];
      }
-	
+
     // Get the plugin config for saml
     $pluginconfig = get_config('auth/saml');
 

--- a/auth/saml/login.php
+++ b/auth/saml/login.php
@@ -17,11 +17,11 @@ if(isset($SESSION->wantsurl)) {
 $saml_config = get_config('auth/saml');
 if(isset($saml_config->autologin)  && $saml_config->autologin)
 {
-	header('Location: '.$samlUrl);
-	exit;
+       header('Location: '.$samlUrl);
+       exit;
 }
 
-$context = get_context_instance(CONTEXT_SYSTEM);
+$context = CONTEXT_SYSTEM::instance();
 $PAGE->set_url("$CFG->httpswwwroot/auth/saml/login.php");
 $PAGE->set_context($context);
 $PAGE->set_pagelayout('login');


### PR DESCRIPTION
The auth/saml module should now be fully ready for 2.7 support. Deperecated functions have been changed to their 2.7 equivalents. `get_context` changed to `CONTEXT::instance` and `print_continue` changed to `$OUTPUT->continue_button`.

I also fixed a notice about empty object created, when saml_config.php doesn't exist.

cc @henrikthorn
