### PR TITLE
Move saml_config.php to dataroot

### DIFF
--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -306,9 +306,9 @@ class auth_plugin_saml extends auth_plugin_base {
 	        exit();
 	    }
 
-      // SAML parameters are in the config variable due all form data is there.
-      // We create a new variable and set the values there.
-      $saml_param = new stdClass();
+        // SAML parameters are in the config variable due all form data is there.
+        // We create a new variable and set the values there.
+        $saml_param = new stdClass();
 
 	    if (!isset ($config->samllib)) {
 	        $saml_param->samllib = '';
@@ -376,25 +376,25 @@ class auth_plugin_saml extends auth_plugin_base {
 	        $config->externalrolemappingsql = ''; 
 	    }
 
-      // Save saml settings in a file        
+        // Save saml settings in a file        
     	$saml_param_encoded = json_encode($saml_param);
 
-			//Place config-file in Moodle-data for future use. 
-      file_put_contents($CFG->dataroot.'/saml_config.php', $saml_param_encoded);
+        //Place config-file in Moodle-data for future use. 
+        file_put_contents($CFG->dataroot.'/saml_config.php', $saml_param_encoded);
 
 	    // Also adding this parameters in database but no need it really.
 	    set_config('samllib',	      $saml_param->samllib,	'auth/saml');
 	    set_config('sp_source',  $saml_param->sp_source,	'auth/saml');
 	    set_config('dosinglelogout',  $saml_param->dosinglelogout,	'auth/saml');
 
-      // Save plugin settings
+        // Save plugin settings
 	    set_config('username',	      $config->username,	'auth/saml');
 	    set_config('supportcourses',  $config->supportcourses,	'auth/saml');
 	    set_config('syncusersfrom',   $config->syncusersfrom,	'auth/saml');
 	    set_config('samlcourses',     $config->samlcourses,	'auth/saml');
 	    set_config('samllogoimage',   $config->samllogoimage,	'auth/saml');
 	    set_config('samllogoinfo',    $config->samllogoinfo,	'auth/saml');
-			set_config('autologin',		    $config->autologin,	'auth/saml');
+        set_config('autologin',		    $config->autologin,	'auth/saml');
 	    set_config('samllogfile',         $config->samllogfile,	'auth/saml');
 	    set_config('samlhookfile',        $config->samlhookfile,	'auth/saml');
 	    set_config('moodlecoursefieldid',   $config->moodlecoursefieldid,   'auth/saml');

--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -301,7 +301,6 @@ class auth_plugin_saml extends auth_plugin_base {
 	    }
 
 	    if(isset($config->initialize_roles)) {  
-	        global $CFG;
 	        $this->initialize_roles($DB, $err);
 	        header('Location: ' . $CFG->wwwroot . '/admin/auth_config.php?auth=saml#rolemapping');
 	        exit();
@@ -377,7 +376,7 @@ class auth_plugin_saml extends auth_plugin_base {
 
         // Save saml settings in a file        
     	$saml_param_encoded = json_encode($saml_param);
-        file_put_contents(dirname(__FILE__) . '/saml_config.php', $saml_param_encoded);
+      file_put_contents(dirname(__FILE__) . '/saml_config.php', $saml_param_encoded);
 
         // Also adding this parameters in database but no need it really.
 	    set_config('samllib',	      $saml_param->samllib,	'auth/saml');

--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -306,9 +306,9 @@ class auth_plugin_saml extends auth_plugin_base {
 	        exit();
 	    }
 
-        // SAML parameters are in the config variable due all form data is there.
-        // We create a new variable and set the values there.
-        $saml_param = new stdClass();
+      // SAML parameters are in the config variable due all form data is there.
+      // We create a new variable and set the values there.
+      $saml_param = new stdClass();
 
 	    if (!isset ($config->samllib)) {
 	        $saml_param->samllib = '';
@@ -374,22 +374,24 @@ class auth_plugin_saml extends auth_plugin_base {
 	    }
 
 
-        // Save saml settings in a file        
+      // Save saml settings in a file        
     	$saml_param_encoded = json_encode($saml_param);
-      file_put_contents(dirname(__FILE__) . '/saml_config.php', $saml_param_encoded);
 
-        // Also adding this parameters in database but no need it really.
+			//Place config-file in Moodle-data for future use. 
+      file_put_contents($CFG->dataroot.'/saml_config.php', $saml_param_encoded);
+
+	    // Also adding this parameters in database but no need it really.
 	    set_config('samllib',	      $saml_param->samllib,	'auth/saml');
 	    set_config('sp_source',  $saml_param->sp_source,	'auth/saml');
 	    set_config('dosinglelogout',  $saml_param->dosinglelogout,	'auth/saml');
 
-        // Save plugin settings
+      // Save plugin settings
 	    set_config('username',	      $config->username,	'auth/saml');
 	    set_config('supportcourses',  $config->supportcourses,	'auth/saml');
 	    set_config('samlcourses',     $config->samlcourses,	'auth/saml');
 	    set_config('samllogoimage',   $config->samllogoimage,	'auth/saml');
 	    set_config('samllogoinfo',    $config->samllogoinfo,	'auth/saml');
-		set_config('autologin',    $config->autologin,	'auth/saml');
+			set_config('autologin',    $config->autologin,	'auth/saml');
 	    set_config('samllogfile',         $config->samllogfile,	'auth/saml');
 	    set_config('samlhookfile',        $config->samlhookfile,	'auth/saml');
 	    set_config('moodlecoursefieldid',   $config->moodlecoursefieldid,   'auth/saml');

--- a/auth/saml/config.php
+++ b/auth/saml/config.php
@@ -33,8 +33,8 @@
 
 
     // Get saml paramters stored in the saml_config.php
-    if(file_exists('saml_config.php')) {
-        $contentfile = file_get_contents('saml_config.php');
+    if(file_exists($CFG->dataroot.'/saml_config.php')) {
+        $contentfile = file_get_contents($CFG->dataroot.'/saml_config.php');
         $saml_param = json_decode($contentfile);    
     }
 

--- a/auth/saml/db/install.php
+++ b/auth/saml/db/install.php
@@ -1,0 +1,5 @@
+<?php
+
+function xmldb_auth_saml_install() {
+    auth_saml_copy_config_file();  
+}

--- a/auth/saml/db/upgrade.php
+++ b/auth/saml/db/upgrade.php
@@ -1,0 +1,11 @@
+<?php
+
+function xmldb_auth_saml_upgrade($oldversion) {
+    require_once 'upgradelib.php';
+    
+    if ($oldversion < 2015061000) {    
+        auth_saml_copy_config_file();
+    }
+    
+    return true;
+}

--- a/auth/saml/db/upgradelib.php
+++ b/auth/saml/db/upgradelib.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Place the config file in the data directory if it's not already there.
+ */
+function auth_saml_copy_config_file() {
+    global $CFG;
+    
+    $source      = $CFG->dirroot.'/auth/saml/saml_config.php';
+    $destination = $CFG->dataroot.'/saml_config.php';
+    
+    if (!file_exists($destination) && !copy($source, $destination)) {
+        $a = (object)array('source' => $source, 'destination' => $destination);
+        throw new moodle_exception('failedtocopyconfig', 'auth_saml', null, $a);
+    }
+}

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -20,11 +20,20 @@ define('SAML_INTERNAL', 1);
             throw(new Exception('Moodle dataroot not found'));
 				}
 				
-        if(!file_exists($CFG->dataroot.'/saml_config.php')) {
+        // Load the SAML config. Before version 2015061000 it is stored in the
+        // plugin root, but is now stored in dataroot. 
+        if (file_exists($CFG->dataroot.'/saml_config.php')) {
+            $contentfile = file_get_contents($CFG->dataroot.'/saml_config.php');
+        }
+        else if (file_exists('./saml_config.php')) {
+            // This user is logging in pending an upgrade from a version
+            // previous to 2015061000.
+            $contentfile = file_get_contents('./saml_config.php');
+        }
+        else {
             throw(new Exception('SAML config params are not set.'));
         }
 				//Get config from config-file placed in Moodledata
-				$contentfile = file_get_contents($CFG->dataroot.'/saml_config.php');
 				$saml_param = json_decode($contentfile);
 
         if(!file_exists($saml_param->samllib.'/_autoload.php')) {

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -9,16 +9,16 @@ define('SAML_INTERNAL', 1);
         // We read saml parameters from a config file instead from the database
         // due we can not operate with the moodle database without load all
         // moodle session issue.
-				//We need to get dataroot from CFG without loading moodle database
+        //We need to get dataroot from CFG without loading moodle database
 
-				$config = file_get_contents('../../config.php');
+        $config = file_get_contents('../../config.php');
 
-				$config = preg_replace('/\s+/', '', $config);
-				if(preg_match('/^.+?\$CFG\-\>dataroot=[\'"](.+?)[\'"];/', $config, $match)){
-					$CFG->dataroot = $match[1];
-				}else {
+        $config = preg_replace('/\s+/', '', $config);
+        if(preg_match('/^.+?\$CFG\-\>dataroot=[\'"](.+?)[\'"];/', $config, $match)){
+            $CFG->dataroot = $match[1];
+        } else {
             throw(new Exception('Moodle dataroot not found'));
-				}
+        }
 				
         // Load the SAML config. Before version 2015061000 it is stored in the
         // plugin root, but is now stored in dataroot. 
@@ -33,8 +33,9 @@ define('SAML_INTERNAL', 1);
         else {
             throw(new Exception('SAML config params are not set.'));
         }
-				//Get config from config-file placed in Moodledata
-				$saml_param = json_decode($contentfile);
+
+        //Get config from config-file placed in Moodledata
+        $saml_param = json_decode($contentfile);
 
         if(!file_exists($saml_param->samllib.'/_autoload.php')) {
             throw(new Exception('simpleSAMLphp lib loader file does not exist: '.$saml_param->samllib.'/_autoload.php'));
@@ -194,7 +195,7 @@ define('SAML_INTERNAL', 1);
 
         if (!$authorize_user) {
             $err['login'] = "<p>" . $authorize_error . "</p>";
-				    saml_error($err, '?logout', $pluginconfig->samllogfile);
+            saml_error($err, '?logout', $pluginconfig->samllogfile);
         }
         
         // Just passes time as a password. User will never log in directly to moodle with this password anyway or so we hope?

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -9,11 +9,25 @@ define('SAML_INTERNAL', 1);
         // We read saml parameters from a config file instead from the database
         // due we can not operate with the moodle database without load all
         // moodle session issue.
-        if(!file_exists('saml_config.php')) {
+				//We need to get dataroot from CFG without loading moodle database
+
+				$config = file_get_contents('../../config.php');
+
+				$config = preg_replace('/\s+/', '', $config);
+				if(preg_match('/^.+?\$CFG\-\>dataroot=[\'"](.+?)[\'"];/', $config, $match)){
+					$CFG->dataroot = $match[1];
+				}else {
+            throw(new Exception('Moodle dataroot not found'));
+				}
+				
+				die(var_dump($CFG));
+ 
+        if(!file_exists($CFG->dataroot.'/saml_config.php')) {
             throw(new Exception('SAML config params are not set.'));
         }
-		$contentfile = file_get_contents('saml_config.php');
-    	$saml_param = json_decode($contentfile);
+				//Get config from config-file placed in Moodledata
+				$contentfile = file_get_contents($CFG->dataroot.'/saml_config.php');
+				$saml_param = json_decode($contentfile);
 
         if(!file_exists($saml_param->samllib.'/_autoload.php')) {
             throw(new Exception('simpleSAMLphp lib loader file does not exist: '.$saml_param->samllib.'/_autoload.php'));
@@ -172,7 +186,7 @@ define('SAML_INTERNAL', 1);
 
         if (!$authorize_user) {
             $err['login'] = "<p>" . $authorize_error . "</p>";
-	    saml_error($err, '?logout', $pluginconfig->samllogfile);
+				    saml_error($err, '?logout', $pluginconfig->samllogfile);
         }
         
         // Just passes time as a password. User will never log in directly to moodle with this password anyway or so we hope?

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -20,8 +20,6 @@ define('SAML_INTERNAL', 1);
             throw(new Exception('Moodle dataroot not found'));
 				}
 				
-				die(var_dump($CFG));
- 
         if(!file_exists($CFG->dataroot.'/saml_config.php')) {
             throw(new Exception('SAML config params are not set.'));
         }

--- a/auth/saml/lang/en/auth_saml.php
+++ b/auth/saml/lang/en/auth_saml.php
@@ -118,3 +118,5 @@ $string['pluginname'] = 'SAML Authentication';
 $string['pluginnotenabled'] = 'Plugin not enabled!';
 $string['syncfromnotenabled'] = 'No external plugin selected. SAML cannot synchronize users on its own.';
 $string['unknownplugin'] = 'SAML does not know how to invoke the sync_users method of the specified plugin: ';
+
+$string['failedtocopyconfig'] = 'Failed to copy the configuration file from {\$a->source} to {\$a->destination}';

--- a/auth/saml/version.php
+++ b/auth/saml/version.php
@@ -1,6 +1,6 @@
 <?php
 
-$plugin->version = 2014112401;
+$plugin->version = 2015061000;
 $plugin->requires = 2013040500;
-$plugin->release = 2013110701;
+$plugin->release = 2015061000;
 $plugin->maturity = 100;


### PR DESCRIPTION
I am picking this up from #14.

1. Added upgrade functionality to copy the saml_config.php file into dataroot if it does not exist.
2. Added a conditional in index.php to load the config file from the old location if it isn't present in the new location. This is because if you were to upgrade the codebase without being logged in, it would be impossible to log in because the config file is still in the old location and will not be in the new location until the upgrade script is run.
3. Tried to clean up some white space issues.