### PR TITLE
Confirm session on auth module init against SP

### DIFF
--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -207,7 +207,7 @@ define('SAML_INTERNAL', 1);
 
         $USER = complete_user_login($user);
 
-        if (function_exists('saml_hook_post_user_created')) {
+        if (function_exists('saml_hook_post_user_created') && !$user_exists && $USER->id) {
             saml_hook_post_user_created($USER);
         }
 
@@ -218,6 +218,7 @@ define('SAML_INTERNAL', 1);
         $USER->loggedin = true;
         $USER->site = $CFG->wwwroot;
         set_moodle_cookie($USER->username);
+      $SESSION->auth_saml['SessionIndex'] = $as->getAuthData('saml:sp:SessionIndex');
 
         if(isset($err) && !empty($err)) {
             auth_saml_error($err, $urltogo, $pluginconfig->samllogfile);


### PR DESCRIPTION
E.g., to support IdP-initiated single log out.

This patch adds a step to the module bootstrap to assess if a user is logged in to Moodle via SAML module. If so, determine if the user is still logged in to the SP and compare the SessionIndex value we stored on initial login against the value from the SP. If the user is no longer signed in, or the SessionIndex does not match (which should not be a normal condition, but it's an added safety check) then log the user out of Moodle.