### PR TITLE
Add support for relative samlhookfile

### DIFF
--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -206,8 +206,8 @@ class auth_plugin_saml extends auth_plugin_base {
 		        $err['samllib'] = get_string('auth_saml_errorbadlib', 'auth_saml', $form->samllib);
 	        }
 
-            if (isset($form->samlhookfile) && $form->samlhookfile != '' && !file_exists($form->samlhookfile)) {
-		        $err['samlhookerror'] = get_string('auth_saml_errorbadhook', 'auth_saml', $form->samlhookfile);
+            if (isset($form->samlhookfile) && $form->samlhookfile != '' && !file_exists(self::resolve_samlhookfile($form->samlhookfile))) {
+		        $err['samlhookerror'] = get_string('auth_saml_errorbadhook', 'auth_saml', self::resolve_samlhookfile($form->samlhookfile));
 	        }
 
 	        if ($form->supportcourses == 'external') {
@@ -639,4 +639,25 @@ class auth_plugin_saml extends auth_plugin_base {
 	    }
 	    return $sucess;
     }	   
+    
+    /**
+     * Get the absolute path to the SAML hook file.
+     * 
+     * @global stdClass $CFG
+     * @param string $path
+     *   The path to the SAML hook file, either absolute or relative to the 
+     *   directory root.
+     * @return string
+     *   The absolute path to the hook file.
+     */
+    public static function resolve_samlhookfile($path) {
+        global $CFG;
+        
+        if (strpos($path, '/') !== 0 && strpos($path, '\\') !== 0) {
+            // This is a relative path because it doesn't with an / or an \.
+            $path = $CFG->dirroot . DIRECTORY_SEPARATOR . $path;
+        } 
+        
+        return $path;
+    }
 }

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -118,7 +118,8 @@ define('SAML_INTERNAL', 1);
     } else {
         // Valid session. Register or update user in Moodle, log him on, and redirect to Moodle front
         if (isset($pluginconfig->samlhookfile) && $pluginconfig->samlhookfile != '') {
-            include_once($pluginconfig->samlhookfile);
+            include_once('auth.php');
+            include_once(auth_plugin_saml::resolve_samlhookfile($pluginconfig->samlhookfile));
         }
 
         if (function_exists('saml_hook_attribute_filter')) {

--- a/auth/saml/lang/en/auth_saml.php
+++ b/auth/saml/lang/en/auth_saml.php
@@ -113,7 +113,7 @@ $string['auth_saml_logfile'] = 'Log file path';
 $string['auth_saml_logfile_description'] = 'Set a filename if you want log the saml plugin errors in a different file that the syslog (Use an absolute path or Moodle will save this file in the moodledata folder)';
 
 $string['auth_saml_samlhookfile'] = 'Hook file path';
-$string['auth_saml_samlhookfile_description'] = 'Set a path if you want to use a hook file that contain your specific funcions';
+$string['auth_saml_samlhookfile_description'] = 'Set a path if you want to use a hook file that contain your specific funcions. The path can either be absolute or relative to your Moodle root directory.';
 $string['auth_saml_errorbadhook'] = "Incorrect SAML plugin hook file: {\$a}";
 
 $string['pluginname'] = 'SAML Authentication';


### PR DESCRIPTION
My attempt to resolve #33.

I wanted to encapsulate the simple logic of resolving a samlhookfile so I put it in a static function on the auth_plugin_saml class. Not sure how I feel about it. Might be better in a generic lib.php file.
