### PR TITLE
improve $CFG->dataroot matching

### DIFF
--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -11,7 +11,7 @@ define('SAML_INTERNAL', 1);
             $config_content =  file_get_contents('../../config.php');
 
             $matches = array();
-            if (preg_match("/[\$]CFG->dataroot[\s]*[\=][\s]*'([\w\/\-\_]*)'/i", $config_content, $matches)) {
+            if (preg_match('/\$CFG->dataroot\s*=\s*["\'](.+)["\'];/i', $config_content, $matches)) {
                 $dataroot = $matches[1];
             }
         }


### PR DESCRIPTION
This fixes Windows systems in particular, as they have `:` in the dataroot path.