### PR TITLE
formerr() deprecation fix for Moodle >= 3.0

### DIFF
--- a/auth/saml/config.php
+++ b/auth/saml/config.php
@@ -26,7 +26,7 @@
  * 2009-07  Added new configuration options
 **/
 
-    global $CFG;
+    global $CFG, $OUTPUT;
 
     require_once("courses.php");
     require_once("roles.php");
@@ -153,7 +153,7 @@ if (isset($err) && !empty($err)) {
         <input name="samllib" type="text" size="30" value="<?php echo $saml_param->samllib; ?>" />
         <?php
         if (isset($err['samllib'])) {
-            $OUTPUT->error_text($err['samllib']);
+            echo $OUTPUT->error_text($err['samllib']);
         }
         ?>
     </td>
@@ -166,7 +166,7 @@ if (isset($err) && !empty($err)) {
         <input name="sp_source" type="text" size="10" value="<?php echo $saml_param->sp_source; ?>" />
         <?php
         if (isset($err['sp_source'])) {
-            $OUTPUT->error_text($err['sp_source']);
+            echo $OUTPUT->error_text($err['sp_source']);
         }
         ?>
     </td>
@@ -227,7 +227,7 @@ if (isset($err) && !empty($err)) {
        <input name="samlhookfile" type="text" size="30" value="<?php echo $config->samlhookfile; ?>" />
        <?php
             if (isset($err['samlhookerror'])) {
-                $OUTPUT->error_text('<p>' . $err['samlhookerror'] . '</p>');
+                echo $OUTPUT->error_text('<p>' . $err['samlhookerror'] . '</p>');
             }
        ?>
 
@@ -376,7 +376,7 @@ else {
 <div id="externalmapping">
     <?php
         if (isset($err['samlexternal'])) {
-            $OUTPUT->error_text($err['samlexternal']);
+            echo $OUTPUT->error_text($err['samlexternal']);
         }
     ?>
     <table id="externalmappinginfo" class="center">


### PR DESCRIPTION
The fix in #40 was incomplete. 
Submitting the form with empty required fields, results in parse error, because `$OUTPUT` is not defined. 
Also the fix is missing an `echo` statement.  [From the wiki](https://docs.moodle.org/dev/Deprecated_functions_in_2.0#formerr_.280.29)
