### PR TITLE
fix construct call

### DIFF
--- a/auth/saml/auth.php
+++ b/auth/saml/auth.php
@@ -29,7 +29,7 @@ class auth_plugin_saml extends auth_plugin_base {
     /**
     * Constructor.
     */
-    function auth_plugin_saml() {
+    function __construct() {
 		$this->authtype = 'saml';
 		$this->config = get_config('auth/saml');
     }


### PR DESCRIPTION
use function with the same name as the class for constructing is deprecated 