### PR TITLE
Removed "core_text" call

### DIFF
--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -143,7 +143,7 @@ define('SAML_INTERNAL', 1);
             auth_saml_error($err['login'], '?logout', $pluginconfig->samllogfile);
         }
         $username = $saml_attributes[$username_field][0];
-        $username = trim(core_text::strtolower($username));
+        $username = trim(strtolower($username));
 
         $saml_courses = array();
         if($pluginconfig->supportcourses != 'nosupport' && isset($pluginconfig->samlcourses)) {


### PR DESCRIPTION
"core_text::strtolower" was deprecated from Moodle and was breaking the plugin. Fixed.