### PR TITLE
Pass saml_attributes along to saml_hook_post_user_created hook

### DIFF
--- a/auth/saml/custom_hook.php
+++ b/auth/saml/custom_hook.php
@@ -122,11 +122,12 @@ function saml_hook_authorize_user($username, $saml_attributes, $authorize_user) 
  name: saml_hook_post_user_created
  arguments:
    - $user: object containing the Moodle user
+   - $saml_attributes: array of SAML attributes
  return value:
    - nothing
  purpose: use this function if you want to make changes to the user object
           or update any external system for statistics or something similar.
 */
-function saml_hook_post_user_created($user) {
+function saml_hook_post_user_created($user, $saml_attributes = array()) {
 
 }

--- a/auth/saml/index.php
+++ b/auth/saml/index.php
@@ -214,7 +214,7 @@ define('SAML_INTERNAL', 1);
         $USER = complete_user_login($user);
 
         if (function_exists('saml_hook_post_user_created')) {
-            saml_hook_post_user_created($USER);
+            saml_hook_post_user_created($USER, $saml_attributes);
         }
 
         if (isset($SESSION->wantsurl) && !empty($SESSION->wantsurl)) {


### PR DESCRIPTION
All of the other hooks receive the attributes.  I want to do some arbitrary actions in a custom hook on the site I'm working on based on attributes, this seems like the easiest way to do it.